### PR TITLE
Update one-page documentation

### DIFF
--- a/docs/modules_contentobject.md
+++ b/docs/modules_contentobject.md
@@ -5,6 +5,7 @@
 - [info](#info)
 - [datamap](#datamap)
 - [delete](#delete)
+- [dump](#dump) _x-ref:_ `eep contentnode dump`
 - [related](#related)
 - [reverserelated](#reverserelated)
 - [contentnode](#contentnode)
@@ -54,7 +55,7 @@ $ eep contentobject delete <object id>
 ```
 
 ## dump
-Delete all content data, suitable for export from ez. See "eep contentnode dump".
+Dump all content data, suitable for export from ez. See "[eep contentnode dump](modules_contentnode.md#dump)".
 
 ## related
 Displays a list of related content objects.   

--- a/docs/one_page.md
+++ b/docs/one_page.md
@@ -476,6 +476,7 @@ $ eep contentnode setsortorder <node id> <sort ordering> <sort direction>
 - [info](#info)
 - [datamap](#datamap)
 - [delete](#delete)
+- [dump](#dump) _x-ref:_ `eep contentnode dump`
 - [related](#related)
 - [reverserelated](#reverserelated)
 - [contentnode](#contentnode)
@@ -525,7 +526,7 @@ $ eep contentobject delete <object id>
 ```
 
 ## dump
-Delete all content data, suitable for export from ez. See "eep contentnode dump".
+Dump all content data, suitable for export from ez. See "[eep contentnode dump](#dump)".
 
 ## related
 Displays a list of related content objects.   


### PR DESCRIPTION
- fixed wording for contentobject module dump description
- added cross ref. links to contentnode dump in TOC and description