### PR TITLE
eep attribute updates

### DIFF
--- a/docs/core_attribute_functions.md
+++ b/docs/core_attribute_functions.md
@@ -11,7 +11,9 @@
 - [toString](#tostring)
 - [createAlias](#createalias)
 - [setField](#setfield)
+- [getField](#getfield)
 - [set](#set)
+- [get](#get)
 - [info](#info)
 - [contentobjectid](#contentobjectid)
 
@@ -162,7 +164,7 @@ Currently supported datatypes: `ezstring ezobjectrelationlist ezinteger ezselect
 
 
 ## fromString
-> Updates a content object's attribute value.
+> Updates a content object data_map attribute value.
 
 *Parameters:*
 - `$contentObjectId` Integer
@@ -176,7 +178,7 @@ Currently supported datatypes: `ezstring ezobjectrelationlist ezinteger ezselect
 
 
 ## toString
-> Returns string representation of a content object attribute value.
+> Returns string representation of a content object data_map attribute value.
 
 *Parameters:*
 - `$contentObjectId` Integer
@@ -184,12 +186,20 @@ Currently supported datatypes: `ezstring ezobjectrelationlist ezinteger ezselect
 
 
 ## setField
-> Directly sets one of the attribute fields (e.g. data_int, data_text1 etc.)
+> Directly sets one of the content class attribute fields (e.g. data_int, data_text1 etc.)
 
 - `$classIdentifier` Integer
 - `$attributeIdentifier` String
 - `$fieldIdentifier` String
 - `$fieldValue` String
+
+
+## getField
+> Directly gets one of the content class attribute fields (e.g. data_int, data_text1 etc.)
+
+- `$classIdentifier` Integer
+- `$attributeIdentifier` String
+- `$fieldIdentifier` String
 
 
 ## set
@@ -198,6 +208,13 @@ Currently supported datatypes: `ezstring ezobjectrelationlist ezinteger ezselect
 - `$contentObjectId` Integer
 - `$attributeIdentifier` String
 - `$attributeValue` Mixed
+
+
+## get
+> Directly gets one of the contentobject attributes (e.g. owner_id, published etc.)
+
+- `$contentObjectId` Integer
+- `$attributeIdentifier` String
 
 
 ## createAlias

--- a/docs/modules_attribute.md
+++ b/docs/modules_attribute.md
@@ -8,7 +8,9 @@
 - [fromstring](#fromstring)
 - [tostring](#tostring)
 - [setfield](#setfield)
+- [getfield](#getfield)
 - [set](#set)
+- [get](#get)
 - [info](#info)
 - [createalias](#createalias)
 - [contentobjectid](#contentobjectid)
@@ -41,13 +43,13 @@ $ eep attribute update <class identifier> <path to newattributexml file>
 ```
 
 ## fromstring
-Calls FromString() on the content object's attribute.
+Calls FromString() on the content object data_map's attribute.
 ```sh
 $ eep attribute fromstring <content object id> <attribute identifier> <new value>
 ```
 
 ## tostring
-Calls ToString() on the content object's attribute.
+Calls ToString() on the content object data_map's attribute.
 ```sh
 $ eep attribute tostring <content object id> <attribute identifier>
 ```
@@ -58,10 +60,22 @@ Directly sets one of the content class attribute fields (e.g. ```data_int```, ``
 $ eep attribute setfield <class identifier> <attributename> <fieldname> <fieldvalue>
 ```
 
+## getfield
+Directly gets one of the content class attribute fields (e.g. ```data_int```, ```data_text1``` etc.)
+```sh
+$ eep attribute getfield <class identifier> <attributename> <fieldname> <fieldvalue>
+```
+
 ## set
 Directly sets one of the contentobject attributes (e.g. owner_id, published etc.)
 ```sh
 $ eep attribute set <content object id> <attribute identifier> <attribute value>
+```
+
+## get
+Directly gets one of the contentobject attributes (e.g. owner_id, published etc.)
+```sh
+$ eep attribute get <content object id> <attribute identifier> <attribute value>
 ```
 
 ## info

--- a/docs/one_page.md
+++ b/docs/one_page.md
@@ -143,7 +143,9 @@ You can override the settings by copying ```.../eep/eepSettings.php``` into your
 - [fromstring](#fromstring)
 - [tostring](#tostring)
 - [setfield](#setfield)
+- [getfield](#getfield)
 - [set](#set)
+- [get](#get)
 - [info](#info)
 - [createalias](#createalias)
 - [contentobjectid](#contentobjectid)
@@ -176,13 +178,13 @@ $ eep attribute update <class identifier> <path to newattributexml file>
 ```
 
 ## fromstring
-Calls FromString() on the content object's attribute.
+Calls FromString() on the content object data_map's attribute.
 ```sh
 $ eep attribute fromstring <content object id> <attribute identifier> <new value>
 ```
 
 ## tostring
-Calls ToString() on the content object's attribute.
+Calls ToString() on the content object data_map's attribute.
 ```sh
 $ eep attribute tostring <content object id> <attribute identifier>
 ```
@@ -193,10 +195,22 @@ Directly sets one of the content class attribute fields (e.g. ```data_int```, ``
 $ eep attribute setfield <class identifier> <attributename> <fieldname> <fieldvalue>
 ```
 
+## getfield
+Directly gets one of the content class attribute fields (e.g. ```data_int```, ```data_text1``` etc.)
+```sh
+$ eep attribute getfield <class identifier> <attributename> <fieldname> <fieldvalue>
+```
+
 ## set
 Directly sets one of the contentobject attributes (e.g. owner_id, published etc.)
 ```sh
 $ eep attribute set <content object id> <attribute identifier> <attribute value>
+```
+
+## get
+Directly gets one of the contentobject attributes (e.g. owner_id, published etc.)
+```sh
+$ eep attribute get <content object id> <attribute identifier> <attribute value>
 ```
 
 ## info
@@ -1093,7 +1107,9 @@ eep user listsubtreenotifications <user_id>
 - [toString](#tostring)
 - [createAlias](#createalias)
 - [setField](#setfield)
+- [getField](#getfield)
 - [set](#set)
+- [get](#get)
 - [info](#info)
 - [contentobjectid](#contentobjectid)
 
@@ -1244,7 +1260,7 @@ Currently supported datatypes: `ezstring ezobjectrelationlist ezinteger ezselect
 
 
 ## fromString
-> Updates a content object's attribute value.
+> Updates a content object data_map attribute value.
 
 *Parameters:*
 - `$contentObjectId` Integer
@@ -1258,7 +1274,7 @@ Currently supported datatypes: `ezstring ezobjectrelationlist ezinteger ezselect
 
 
 ## toString
-> Returns string representation of a content object attribute value.
+> Returns string representation of a content object data_map attribute value.
 
 *Parameters:*
 - `$contentObjectId` Integer
@@ -1266,12 +1282,20 @@ Currently supported datatypes: `ezstring ezobjectrelationlist ezinteger ezselect
 
 
 ## setField
-> Directly sets one of the attribute fields (e.g. data_int, data_text1 etc.)
+> Directly sets one of the content class attribute fields (e.g. data_int, data_text1 etc.)
 
 - `$classIdentifier` Integer
 - `$attributeIdentifier` String
 - `$fieldIdentifier` String
 - `$fieldValue` String
+
+
+## getField
+> Directly gets one of the content class attribute fields (e.g. data_int, data_text1 etc.)
+
+- `$classIdentifier` Integer
+- `$attributeIdentifier` String
+- `$fieldIdentifier` String
 
 
 ## set
@@ -1280,6 +1304,13 @@ Currently supported datatypes: `ezstring ezobjectrelationlist ezinteger ezselect
 - `$contentObjectId` Integer
 - `$attributeIdentifier` String
 - `$attributeValue` Mixed
+
+
+## get
+> Directly gets one of the contentobject attributes (e.g. owner_id, published etc.)
+
+- `$contentObjectId` Integer
+- `$attributeIdentifier` String
 
 
 ## createAlias

--- a/lib/AttributeFunctions.php
+++ b/lib/AttributeFunctions.php
@@ -712,6 +712,34 @@ class AttributeFunctions
     }
 
     //--------------------------------------------------------------------------
+    public static function getField( $classIdentifier, $attributeIdentifier, $fieldIdentifier )
+    {
+        $contentClass = eZContentClass::fetchByIdentifier( $classIdentifier );
+
+        if( !$contentClass )
+            throw new Exception( "Failed to instantiate content class [" . $classIdentifier . "]" );
+
+        $classDataMap = $contentClass->attribute( "data_map" );
+
+        if( !isset( $classDataMap[ $attributeIdentifier ] ) )
+            throw new Exception( "Content class '" . $classIdentifier . "' does not contain this attribute: [" . $attributeIdentifier . "]" );
+
+        $fieldValue     = $classDataMap[ $attributeIdentifier ]->attribute( $fieldIdentifier );
+        $fieldValueType = gettype( $fieldValue );
+
+        if ( in_array( $fieldValueType, array( 'array', 'object' ) ) )
+        {
+            $fieldValue = serialize( $fieldValue );
+        }
+        elseif ( $fieldValueType == 'boolean' )
+        {
+            $fieldValue = (integer) $fieldValue;
+        }
+
+        return $fieldValue;
+    }
+
+    //--------------------------------------------------------------------------
     public static function setAttribute( $contentObjectId, $attributeIdentifier, $attributeValue )
     {
         $contentObject = eZContentObject::fetch( $contentObjectId );
@@ -723,11 +751,42 @@ class AttributeFunctions
 
         if ( !$contentObject->hasAttribute( $attributeIdentifier ) )
         {
-            throw new Exception( "This is not a content object attribute identifier [" . $attributeIdentifier . "]" );   
+            throw new Exception( "This is not a content object attribute identifier [" . $attributeIdentifier . "]" );
         }
 
         $contentObject->setAttribute( $attributeIdentifier, $attributeValue );
         $contentObject->store();
+    }
+
+    //--------------------------------------------------------------------------
+    public static function getAttribute( $contentObjectId, $attributeIdentifier )
+    {
+        $contentObject = eZContentObject::fetch( $contentObjectId );
+
+        if ( !$contentObject )
+        {
+            throw new Exception( "This is not a content object [" . $contentObjectId . "]" );
+        }
+
+        if ( !$contentObject->hasAttribute( $attributeIdentifier ) )
+        {
+            throw new Exception( "This is not a content object attribute identifier [" . $attributeIdentifier . "]" );
+        }
+
+        $attributeValue     = $contentObject->attribute( $attributeIdentifier );
+        $attributeValueType = gettype( $attributeValue );
+        $attributeValue     = "";
+
+        if ( in_array( $attributeValueType, array( 'array', 'object' ) ) )
+        {
+            $attributeValue = serialize( $attributeValue );
+        }
+        elseif ( $attributeValueType == 'boolean' )
+        {
+            $attributeValue = (integer) $attributeValue;
+        }
+
+        return $attributeValue;
     }
 
     //--------------------------------------------------------------------------

--- a/modules/attribute/index.php
+++ b/modules/attribute/index.php
@@ -18,7 +18,8 @@ class attribute_commands
     const attribute_fromstring      = "fromstring";
     const attribute_tostring        = "tostring";
     const attribute_setfield        = "setfield";
-    //const attribute_get             = "get";
+    const attribute_getfield        = "getfield";
+    const attribute_get             = "get";
     const attribute_set             = "set";
     const attribute_info            = "info";
     const attribute_createalias     = "createalias";
@@ -35,7 +36,8 @@ class attribute_commands
         , self::attribute_newattributexml
         , self::attribute_update
         , self::attribute_setfield
-        //, self::attribute_get
+        , self::attribute_getfield
+        , self::attribute_get
         , self::attribute_set
         , self::attribute_info
         , self::attribute_createalias
@@ -56,11 +58,11 @@ delete
   eep attribute delete <class identifier> <attribute identifier>
 
 fromstring
-- calls FromString() on the attribute
+- calls FromString() on the content object data_map's attribute
   eep attribute fromstring <content object id> <attribute identifier> <new value>
 
 tostring
-- calls ToString on the attribute
+- calls ToString on the content object data_map's attribute
   eep attribute tostring <content object id> <attribute identifier>
 
 migrate
@@ -78,11 +80,15 @@ update
   eep attribute update <class identifier> <path to newattributexml file>
 
 setfield
-- directly sets one of the attribute fields (e.g. data_int, data_text1 etc.)
+- directly sets one of the content class attribute fields (e.g. data_int, data_text1 etc.)
   eep attribute setfield <class identifier> <attributename> <fieldname> <fieldvalue>
 
+getfield
+- directly gets one of the content class attribute fields (e.g. data_int, data_text1 etc.)
+  eep attribute getfield <class identifier> <attributename> <fieldname> <fieldvalue>
+
 get
-- display contentobject attributes (via get_attribute() )
+- directly gets one of the contentobject attributes (e.g. owner_id, published etc.)
   eep attribute get <content object id> <attribute identifier>
   
 set
@@ -234,29 +240,19 @@ EOT;
                 AttributeFunctions::setField( $classIdentifier, $attributeIdentifier, $fieldIdentifier, $fieldValue );
                 break;
 
-            /*
-             * totally disfunctional ...
-             * 
+            case self::attribute_getfield:
+                $classIdentifier = $param1;
+                $attributeIdentifier = $param2;
+                $fieldIdentifier = $param3;
+                echo AttributeFunctions::getField( $classIdentifier, $attributeIdentifier, $fieldIdentifier ) . "\n";
+                break;
+
             case self::attribute_get:
                 $contentObjectId = $param1;
                 $attributeIdentifier = $param2;
-                
-                $contentObject = eZContentObject::fetch( $contentObjectId );
-                if ( !$contentObject )
-                {
-                    throw new Exception( "This is not a content object [" . $contentObjectId . "]" );
-                }
-                print_r($contentObject);
-                $userSetting = eZUserSetting::fetch( $contentObject->attribute( 'id' ) );
-                // this does not work:
-                $value = $contentObject->attribute( 'is_enabled' );
-                // this works:
-                //$value = $userSetting->attribute( 'is_enabled' );
-                echo $value . "\n";
-                //AttributeFunctions::setAttribute( $contentObjectId, $attributeIdentifier, $attributeValue );
+                echo AttributeFunctions::getAttribute( $contentObjectId, $attributeIdentifier ) . "\n";
                 break;
-            */
-                
+
             case self::attribute_set:
                 $contentObjectId = $param1;
                 $attributeIdentifier = $param2;


### PR DESCRIPTION
The update re-enables the attribute module get operation to display core attribute data e.g. owner_id, published
It also introduces a getfield operation to get content class attribute field data, complimenting the existing setfield operation.

Lastly, inline and main documentation have been updated to outline the new operations and functions.
Existing attribute docs have been updated to be more specific about which type of attribute an operation works on.
e.g. content object, content object data_map, content class