### PR TITLE
Updated standard modules list in bash completion script

### DIFF
--- a/bash_completion/eep
+++ b/bash_completion/eep
@@ -8,7 +8,7 @@ _eep()
     
     _get_comp_words_by_ref cur prev
  
-    standardmodules='attribute contentclass contentclassgroup contentnode contentobject create crondaemon ezfind ezflow help knowledgebase list section trash use user'
+    standardmodules='attribute cache contentclass contentclassgroup contentnode contentobject create crondaemon ezfind ezflow help knowledgebase list section trash use user'
 
     if [[ 1 == "$COMP_CWORD" ]]; then
         COMPREPLY=( $( compgen -W "$standardmodules" -- $cur ) )


### PR DESCRIPTION
Cache module was missing from the completion list